### PR TITLE
Fix casing causing duplicate options

### DIFF
--- a/Tasks/PurgeV1/task.json
+++ b/Tasks/PurgeV1/task.json
@@ -51,7 +51,7 @@
       "label": "Purge method",
       "helpMarkDown": "Method to perform content purging by\n\n- `Delete` - selecting this method means the content that is currently in Akamai’s edge server caches is never served.\n- `Invalidate` - Select this method to mark the cached content as invalid",
       "required": true,
-      "defaultValue": "Invalidate",
+      "defaultValue": "invalidate",
       "options": {
         "delete": "Delete",
         "invalidate": "Invalidate"


### PR DESCRIPTION
Incorrect casing was causing duplicates in YAML GUI:

<img width="331" alt="image" src="https://user-images.githubusercontent.com/30583851/170374098-e4fa16f1-4438-4413-836e-c71eeefee269.png">
