### PR TITLE
Address parameters case issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.1.*
 
+`2022-06-15`
+
+- Address parameters case issues
+
 `2022-05-24`
 
 - Add CP Code purge by support

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ URL's CP code.
   inputs:
     edgegridEndpoint: My-Endpoint # Required
     network: My-Network           # Options: staging, production
-    purgeType: url                # Optional. Options: url (default), cpcode
+    purgeType: url                # Optional. Options: url (default), cpCode
     # purgeMethod: Invalidate     # Optional. Options: invalidate (default), delete
     urls: |                       # Required when purgeType: url
       https://my.domain/one
@@ -69,9 +69,9 @@ URL's CP code.
   inputs:
     edgegridEndpoint: My-Endpoint # Required
     network: My-Network           # Options: staging, production
-    purgeType: cpcode             # Optional. Options: url (default), cpcode
+    purgeType: cpCode             # Optional. Options: url (default), cpCode
     # purgeMethod: Invalidate     # Optional. Options: invalidate (default), delete
-    cpCodes: |                    # Required when purgeType: cpcode
+    cpCodes: |                    # Required when purgeType: cpCode
       123456
       789123
     wait: false                   # Options: true, false

--- a/Tasks/PurgeV1/helpers/taskhelper.ts
+++ b/Tasks/PurgeV1/helpers/taskhelper.ts
@@ -124,7 +124,7 @@ export class TaskHelper implements ITaskHelper {
 
         };
 
-        switch (purgeType) {
+        switch (purgeType.toLowerCase()) {
 
             case "url": {
 
@@ -132,17 +132,21 @@ export class TaskHelper implements ITaskHelper {
 
                 break;
 
-            } case "cpCode": {
+            } case "cpcode": {
 
                 parameters = await this.readCPCodeInputs(parameters);
 
                 break;
 
+            } default : {
+
+                throw new Error("Invalid purge type");
+
             }
 
         }
 
-        switch (purgeMethod) {
+        switch (purgeMethod.toLowerCase()) {
 
             case "delete": {
 
@@ -155,6 +159,10 @@ export class TaskHelper implements ITaskHelper {
                 parameters.purgeMethod = PurgeMethod.invalidate;
 
                 break;
+
+            } default : {
+
+                throw new Error("Invalid purge method");
 
             }
 


### PR DESCRIPTION
Fix documentation to represent camelcase

`cpcode` > `cpCode`